### PR TITLE
Add retry for OTP when it is not received in 3 minutes

### DIFF
--- a/src/covid-vaccine-slot-booking.py
+++ b/src/covid-vaccine-slot-booking.py
@@ -118,24 +118,11 @@ def main():
                 beep(WARNING_BEEP_DURATION[0], WARNING_BEEP_DURATION[1])
                 print('Token is INVALID.')
                 token_valid = False
+                token = None
 
-                tryOTP = 'y'
-                if tryOTP.lower() == 'y':
-                    if mobile:
-                        tryOTP = 'y'
-                        if tryOTP.lower() == 'y':
-                            token = generate_token_OTP(mobile, base_request_header)
-                            token_valid = token is not None
-                        else:
-                            token_valid = False
-                            print("Exiting")
-                    else:
-                        mobile = input("Enter the registered mobile number: ")
-                        token = generate_token_OTP(mobile, base_request_header)
-                        token_valid = token is not None
-                else:
-                    print("Exiting")
-                    os.system("pause")
+                while token is None:
+                    token = generate_token_OTP(mobile, base_request_header)
+                token_valid = True
 
     except Exception as e:
         print(str(e))

--- a/src/covid-vaccine-slot-booking.py
+++ b/src/covid-vaccine-slot-booking.py
@@ -15,12 +15,14 @@ def main():
         base_request_header = {
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'
         }
-
+        
+        token = None
         if args.token:
             token = args.token
         else:
             mobile = input("Enter the registered mobile number: ")
-            token = generate_token_OTP(mobile, base_request_header)
+            while token is None:
+                token = generate_token_OTP(mobile, base_request_header)
 
         request_header = copy.deepcopy(base_request_header)
         request_header["Authorization"] = f"Bearer {token}"
@@ -123,14 +125,14 @@ def main():
                         tryOTP = 'y'
                         if tryOTP.lower() == 'y':
                             token = generate_token_OTP(mobile, base_request_header)
-                            token_valid = True
+                            token_valid = token is not None
                         else:
                             token_valid = False
                             print("Exiting")
                     else:
                         mobile = input("Enter the registered mobile number: ")
                         token = generate_token_OTP(mobile, base_request_header)
-                        token_valid = True
+                        token_valid = token is not None
                 else:
                     print("Exiting")
                     os.system("pause")

--- a/src/utils.py
+++ b/src/utils.py
@@ -431,7 +431,7 @@ def get_min_age(beneficiary_dtls):
 
 def generate_token_OTP(mobile, request_header):
     """
-    This function generate OTP and returns a new token
+    This function generate OTP and returns a new token or None when not able to get token
     """
     storage_url = 'https://kvdb.io/3YgXf9PHYHbX6NsF7zP6Us/' + mobile
     print("clearing OTP bucket: " + storage_url)
@@ -446,10 +446,12 @@ def generate_token_OTP(mobile, request_header):
     else:
         print('Unable to Create OTP')
         print(txnId.text)
-        os.system("pause")
+        time.sleep(5) # Saftey net againt rate limit
+        return None
 
     time.sleep(10)
-    while True:
+    t_end = time.time() + 60 * 3 #try to read OTP for atmost 3 minutes
+    while time.time() < t_end:
         response = requests.get(storage_url)
         if response.status_code == 200:
             print("OTP SMS is:" +  response.text)
@@ -467,6 +469,9 @@ def generate_token_OTP(mobile, request_header):
             print("error fetching OTP API:" + response.text)
             time.sleep(5)
 
+    if not OTP:
+        return None
+
     print("Parsed OTP:" + OTP)
 
 
@@ -479,7 +484,7 @@ def generate_token_OTP(mobile, request_header):
     else:
         print('Unable to Validate OTP')
         print(token.text)
-        os.system("pause")
+        return None
 
     print(f'Token Generated: {token}')
     return token


### PR DESCRIPTION
Added a retry mechanism to generate OTP again after 3 minutes  of failure to fetch OTP.

- Replaced infinite while loop to fetch OTP from IFFT with timer of 3 minutes.
- If we don't receive OTP from IIFT for 3 minutes, retry sending OTP again to mobile number.