### PR TITLE
Help in release management

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,37 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'docs'
+      - 'documentation'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+exclude-labels:
+  - 'skip-changelog'
+sort-direction: 'ascending'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,9 @@ name: CI Windows EXE Build
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events
   push:
-    paths:
-      - '**.py'
-
-  pull_request:
-    paths:
-      - '**.py'
+    tags:
+      - v*
 
 
   # Allows you to run this workflow manually from the Actions tab
@@ -51,9 +46,18 @@ jobs:
           cd ..
           move src\dist\covid-vaccine-slot-booking.exe .
       
-      # Commit and push EXE file to branch
-      - name: Push EXE to branch
-        run: |
-          git add covid-vaccine-slot-booking.exe
-          git commit -m "rebuilt via GitHub Actions"
-          git push --force
+      # Push EXE file to release
+      - name: Upload windows executable to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: covid-vaccine-slot-booking.exe
+          tag: ${{ github.ref }}
+
+      # Push APK to release.
+      - name: Upload android package to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: CoWinOtpRetreiver.apk
+          tag: ${{ github.ref }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
On every PR Merge, release drafter will create a draft release with all change logs. 
After a few days or when you have confidence in your `main` branch, you can release the draft. On releasing, the action will upload exe & apk to that release.

This will help in #301 

@BlackRider97 @Nakul93 @bombardier-gif @shailesh If you are okay with this idea, i will update the README & complete the PR.