### PR TITLE
Revert "[300] Fixes location search issue for option 1"

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -218,7 +218,6 @@ def collect_user_details(request_header):
     else:
         # Collect vaccination center preference
         location_dtls = get_pincodes()
-        pin_code_location_dtls = location_dtls
 
     print(
         "\n================================= Additional Info =================================\n"


### PR DESCRIPTION
Reverts bombardier-gif/covid-vaccine-booking#309

@bombardier-gif Reverts bombardier-gif/covid-vaccine-booking#309 The PR is causing to show location details twice:
#312 has fixed the issue and this isn't needed.
I have verified it.

```
	location_dtls:
+-------+-----------+--------------+
|   idx |   pincode |   alert_freq |
+=======+===========+==============+
|     1 |    825404 |          440 |
+-------+-----------+--------------+
	pin_code_location_dtls:
+-------+-----------+--------------+
|   idx |   pincode |   alert_freq |
+=======+===========+==============+
|     1 |    825404 |          440 |
+-------+-----------+--------------+
```