### PR TITLE
Personal KVDB buckets [To solve: error fetching OTP API:Not Found]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 <br>
 
 ## KVDB setup
-Regardless of Android or iOS, you will need a KVDB bucket configured to act as a key value store for your OTP messages coming from the IFTTT app or CoWIN OTP Retriever.
+Regardless of Android or iOS, you will need a KVDB bucket configured to act as a key value store for your OTP messages coming from the IFTTT app or CoWIN OTP Retriever. If you don't use your personal kvdb bucket, the script will use a public bucket which will be shared with other users and might not be reliable. You will need to update your personal key every 14 days or buy a pro account on kvdb.
 Steps to get your own KVDB bucket:
 
 1. Go to https://kvdb.io/
@@ -137,12 +137,12 @@ Steps to get your own KVDB bucket:
 
 <br>
 
-### Option 2: CoWIN OTP Retriever (Presently not working because KVDB bucket key which is hardcoded in the app has expired. Will be updated soon.)
+### Option 2: CoWIN OTP Retriever
 1. Install the [CoWinOTPRetriever Android app](./CoWinOtpRetreiver.apk?raw=true) by enabling installation from unknown sources.
 2. Follow this guide to install apps from unknown sources: https://www.verizon.com/support/knowledge-base-222186/
 3. Allow the app to run in background so that the app does not stop even if you multi-task or leave the phone idle. (Note that, there still might be some phone model specific settings and optimizations which could stop the app from running in background. Check point number 8)
 4. Grant sms access to allow the app to read CoWIN OTP sms.
-5. Enter 10 digit mobile number registered on the CoWIN portal.
+5. Enter 10 digit mobile number registered on the CoWIN portal. Also enter your personal KVDB bucket value.
 6. Switch ON the OTP Listener.
 7. If the OTP is successfully sent to the key value store, you will see the status as shown below.
 8. Ensure that the battery saver mode, and all other optimizations are removed. The app should always run (This is the key for quick response). 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 <br>
 
 ## KVDB setup
-Regardless of Android or iOS, you will need a KVDB bucket configured to act as a key value store for your OTP messages coming from the IFTTT app or CoWIN OTP Retriever. If you don't use your personal kvdb bucket, the script will use a public bucket which will be shared with other users and might not be reliable. You will need to update your personal key every 14 days or buy a pro account on kvdb.
+Regardless of Android or iOS, you will need a KVDB bucket configured to act as a key value store for your OTP messages coming from the IFTTT app or CoWIN OTP Retriever. You will need to update your personal key every 14 days or buy a pro account on kvdb.
 Steps to get your own KVDB bucket:
 
 1. Go to https://kvdb.io/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@
 
 <br>
 
+## KVDB setup
+Regardless of Android or iOS, you will need a KVDB bucket configured to act as a key value store for your OTP messages coming from the IFTTT app or CoWIN OTP Retriever.
+Steps to get your own KVDB bucket:
+
+1. Go to https://kvdb.io/
+2. Click on Get started now
+3. Enter your email and click on Create bucket
+4. You will get a bucket key. It is just a random sequence of characters eg. ASth4wnvVDPkg2bdjsiqMN
+5. Keep this key saved somewhere in your notes. We will need it.
+
 ## Setup Guide for Android
 
 ### Option 1: IFTTT
@@ -91,7 +101,7 @@
 3. If this..... click on Android SMS trigger
 4. Select "New SMS received matches search" and use CoWIN as the search key
 5. Then... Choose a service named Webhooks and then select make a web request
-6. Paste the url:  https://kvdb.io/ASth4wnvVDPkg2bdjsiqMN/99XXXXXXXX replace 99XXXXXXXX with your phone number
+6. Paste the url: https://kvdb.io/<kvdb_bucket>/99XXXXXXXX replace 99XXXXXXXX with your phone number and <kvdb_bucket> with your own key that you got in the previous step of KVDB setup.
 7. Method is PUT
 8. Content Type PlainText
 9. Body: Add ingredient and select Text
@@ -127,7 +137,7 @@
 
 <br>
 
-### Option 2: CoWIN OTP Retriever
+### Option 2: CoWIN OTP Retriever (Presently not working because KVDB bucket key which hardcoded in the app has expired. Will be updated soon.)
 1. Install the [CoWinOTPRetriever Android app](./CoWinOtpRetreiver.apk?raw=true) by enabling installation from unknown sources.
 2. Follow this guide to install apps from unknown sources: https://www.verizon.com/support/knowledge-base-222186/
 3. Allow the app to run in background so that the app does not stop even if you multi-task or leave the phone idle. (Note that, there still might be some phone model specific settings and optimizations which could stop the app from running in background. Check point number 8)
@@ -158,7 +168,7 @@
 3. Select the `Message` option
 4. Put `CoWIN` in the Message Contains option & leave everything blank. Tap on Next button
 5. Tap on `Add action` and search for the option `Set Variable`. Give the variable name `text` and input as `Shortcut Input`
-6. Then add another action and select `URL` and paste the url: https://kvdb.io/ASth4wnvVDPkg2bdjsiqMN/99XXXXXXXX replace 99XXXXXXXX with your phone number
+6. Then add another action and select `URL` and paste the url: https://kvdb.io/<kvdb_bucket>/99XXXXXXXX replace 99XXXXXXXX with your phone number and <kvdb_bucket> with your bucket value from the KVDB setup step
 7. Then add another action and select `Get Contents of Url`. Click on show more. Change the method to `PUT`. Request Body to `File` and in the file row tap on `Choose Variable` and select `text` which we defined in Step 6.
 8. Click Next and save this automation.
 9. Clone this repository

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Steps to get your own KVDB bucket:
 
 <br>
 
-### Option 2: CoWIN OTP Retriever (Presently not working because KVDB bucket key which hardcoded in the app has expired. Will be updated soon.)
+### Option 2: CoWIN OTP Retriever (Presently not working because KVDB bucket key which is hardcoded in the app has expired. Will be updated soon.)
 1. Install the [CoWinOTPRetriever Android app](./CoWinOtpRetreiver.apk?raw=true) by enabling installation from unknown sources.
 2. Follow this guide to install apps from unknown sources: https://www.verizon.com/support/knowledge-base-222186/
 3. Allow the app to run in background so that the app does not stop even if you multi-task or leave the phone idle. (Note that, there still might be some phone model specific settings and optimizations which could stop the app from running in background. Check point number 8)

--- a/src/covid-vaccine-slot-booking.py
+++ b/src/covid-vaccine-slot-booking.py
@@ -45,10 +45,11 @@ def main():
             filename = filename + mobile + ".json"
             otp_pref = input("\nDo you want to enter OTP manually, instead of auto-read? \nRemember selecting n would require some setup described in README (y/n Default n): ")
             otp_pref = otp_pref if otp_pref else "n"
-            kvdb_bucket = input("If you have your personal kvdb bucket, please enter it here. Else just press enter: ")
+            kvdb_bucket = input("Please refer KVDB setup in ReadMe to setup your own KVDB bucket. Please enter your KVDB bucket value here: ")
             if not kvdb_bucket:
-                kvdb_bucket = "8o67Wac93Ha4NTMvQ3f6Me"
-            print("### Note ###\nPlease make sure the configured URL on your phone is: " + "https://kvdb.io/" + kvdb_bucket + "/" + mobile)
+                print("Sorry, having your private KVDB bucket is mandatory. Please refer ReadMe and create your own private KVBD bucket.")
+                sys.exit()
+            print("\n### Note ### Please make sure the URL configured in the IFTTT/Shortcuts app on your phone is: " + "https://kvdb.io/" + kvdb_bucket + "/" + mobile + "\n")
             while token is None:
                 if otp_pref=="n":
                     try:

--- a/src/covid-vaccine-slot-booking.py
+++ b/src/covid-vaccine-slot-booking.py
@@ -45,10 +45,11 @@ def main():
             filename = filename + mobile + ".json"
             otp_pref = input("\nDo you want to enter OTP manually, instead of auto-read? \nRemember selecting n would require some setup described in README (y/n Default n): ")
             otp_pref = otp_pref if otp_pref else "n"
+            kvdb_bucket = input("Please enter your kvdb bucket key: ")
             while token is None:
                 if otp_pref=="n":
                     try:
-                        token = generate_token_OTP(mobile, base_request_header)
+                        token = generate_token_OTP(mobile, base_request_header, kvdb_bucket)
                     except Exception as e:
                         print(str(e))
                         print('OTP Retrying in 5 seconds')
@@ -135,7 +136,7 @@ def main():
                     while token is None:
                         if otp_pref=="n":
                             try:
-                                token = generate_token_OTP(mobile, base_request_header)
+                                token = generate_token_OTP(mobile, base_request_header, kvdb_bucket)
                             except Exception as e:
                                 print(str(e))
                                 print('OTP Retrying in 5 seconds')

--- a/src/covid-vaccine-slot-booking.py
+++ b/src/covid-vaccine-slot-booking.py
@@ -45,7 +45,10 @@ def main():
             filename = filename + mobile + ".json"
             otp_pref = input("\nDo you want to enter OTP manually, instead of auto-read? \nRemember selecting n would require some setup described in README (y/n Default n): ")
             otp_pref = otp_pref if otp_pref else "n"
-            kvdb_bucket = input("Please enter your kvdb bucket key: ")
+            kvdb_bucket = input("If you have your personal kvdb bucket, please enter it here. Else just press enter: ")
+            if not kvdb_bucket:
+                kvdb_bucket = "8o67Wac93Ha4NTMvQ3f6Me"
+            print("### Note ###\nPlease make sure the configured URL on your phone is: " + "https://kvdb.io/" + kvdb_bucket + "/" + mobile)
             while token is None:
                 if otp_pref=="n":
                     try:

--- a/src/utils.py
+++ b/src/utils.py
@@ -523,7 +523,6 @@ def book_appointment(request_header, details, mobile, generate_captcha_pref):
                     "                        Hey, Hey, Hey! It's your lucky day!                       "
                 )
                 print("\nPress any key thrice to exit program.")
-                requests.put("https://kvdb.io/thofdz57BqhTCaiBphDCp/" + str(uuid.uuid4()), data={})
                 os.system("pause")
                 os.system("pause")
                 os.system("pause")
@@ -1035,11 +1034,11 @@ def clear_bucket_and_send_OTP(storage_url, mobile, request_header):
     return txnId
 
 
-def generate_token_OTP(mobile, request_header):
+def generate_token_OTP(mobile, request_header, kvdb_bucket):
     """
     This function generate OTP and returns a new token or None when not able to get token
     """
-    storage_url = "https://kvdb.io/ASth4wnvVDPkg2bdjsiqMN/" + mobile
+    storage_url = "https://kvdb.io/" + kvdb_bucket + "/" + mobile
 
     txnId = clear_bucket_and_send_OTP(storage_url, mobile, request_header)
 


### PR DESCRIPTION
**Issue**
The script uses http://kvdb.io/ as a bridge between the phone receiving the OTPs, sending them using apps like IFTTT for the Python script to be able to read those OTPs. The KVDB bucket which is being used, however is of a trial account which has expired. 

**Solution**
Let the users create their own KVDB accounts and use their bucket keys. If they wish, they can purchase a Pro account which won't get expired every 14 days. 

**Next steps**
- The script asks the kvdb bucket key every time it is run. We can improve this by saving it to a file somewhere. 