### PR TITLE
Feature/use local wifi to get otp

### DIFF
--- a/src/CoWinOTPRetriever/app/src/main/java/com/indiacowin/cowinotpretriever/OtpSenderOverWifi.java
+++ b/src/CoWinOTPRetriever/app/src/main/java/com/indiacowin/cowinotpretriever/OtpSenderOverWifi.java
@@ -1,0 +1,57 @@
+package com.indiacowin.cowinotpretriever;
+
+import android.util.Log;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.nio.charset.Charset;
+
+public class OtpSenderOverWifi implements Closeable {
+    DatagramSocket server;
+    int port;
+
+    public OtpSenderOverWifi(int port) throws SocketException {
+        this.port = port;
+        server = new DatagramSocket(port);
+        server.setSoTimeout(10000);
+        server.setBroadcast(true);
+    }
+
+    public void sendOtp(String otp, String password) throws IOException {
+        try {
+            //broadcasting self details
+            InetAddress addr = InetAddress.getByName("255.255.255.255");
+            byte[] msg = String.format("%s::%s", password, otp).getBytes(Charset.defaultCharset());
+            DatagramPacket data = new DatagramPacket(msg, msg.length, addr, port);
+            server.send(data);
+        } catch (IOException e) {
+            Log.e("OtpSenderOverWifi", "Error in sending otp to laptop server", e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        server.close();
+    }
+
+    public void sendOtpWithRetry(String password, String otp, int retry) {
+        new Thread(() -> {
+            int remainingRetry = retry;
+            while (remainingRetry > 0 ){
+                remainingRetry--;
+                try {
+                    sendOtp(otp, password);
+                    break;
+                } catch (IOException e) {
+                    // Do nothing
+                }
+            }
+        }).start();
+    }
+
+}

--- a/src/CoWinOTPRetriever/app/src/main/res/layout/activity_main.xml
+++ b/src/CoWinOTPRetriever/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,18 +7,60 @@
     android:background="@color/atomic"
     tools:context=".MainActivity">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/PasswordLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="248dp"
+            android:fontFamily="sans-serif"
+            android:text="@string/enter_password_used_while_script_run"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.511"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+        android:id="@+id/PasswordEntry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:autofillHints="AUTOFILL_HINT_PASSWORD"
+        android:ems="10"
+        android:labelFor="@id/PasswordEntry"
+        android:inputType="text"
+        android:textColor="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/PasswordLabel" />
+
+    <TextView
+        android:id="@+id/VerticalSeparator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif"
+        android:text="@string/or_str"
+        android:textColor="@color/yellow"
+        android:layout_marginTop="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/PasswordEntry"/>
+
     <TextView
         android:id="@+id/PhoneNumberLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="288dp"
         android:fontFamily="sans-serif"
         android:text="@string/enter_phone_number"
         android:textColor="@color/white"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="15dp"
         app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/VerticalSeparator"  />
 
     <EditText
         android:id="@+id/PhoneNumberEntry"
@@ -87,15 +129,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/KvdbBucketLabel" />
 
-    <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="303dp"
-        android:layout_height="192dp"
-        android:layout_marginTop="16dp"
-        app:layout_constraintBottom_toTopOf="@+id/PhoneNumberLabel"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.437"
-        app:srcCompat="@drawable/ic_upload_image" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="303dp"
+            android:layout_height="192dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintBottom_toTopOf="@+id/PhoneNumberLabel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.121"
+            app:srcCompat="@drawable/ic_upload_image" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/src/CoWinOTPRetriever/app/src/main/res/values/strings.xml
+++ b/src/CoWinOTPRetriever/app/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="generic_server_down">KVDB server is down</string>
     <string name="no_internet">No internet connection</string>
     <string name="generic_error">An unknown error occurred</string>
+    <string name="enter_password_used_while_script_run">Enter Password Used while script run</string>
+    <string name="or_str">Or,</string>
 </resources>

--- a/src/discoveryservice.py
+++ b/src/discoveryservice.py
@@ -1,0 +1,76 @@
+import socket
+import time
+import re
+import otp_info
+
+# import thread module
+from _thread import *
+
+
+OTP_PAT = re.compile(r'\b\d{6}\b')
+
+
+def bind_udp_socket():
+    # Create a TCP/IP socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    # Bind the socket to listen all broadcast packet on the port 10041
+    server_address = ('', 10041)
+    print('starting udp server on %s port %s' % server_address)
+    sock.bind(server_address)
+
+    return sock
+
+
+def receive_otp_from_mobile(sock, password):
+    while True:
+        print('\n waiting to receive message from mobile')
+        data, address = sock.recvfrom(4096)
+
+        print('\n received %s bytes from %s' % (len(data), address))
+        print(data)
+
+        if data:
+
+            passwd_from_phone, otp_msg = data.decode('utf-8').split("::")
+            if passwd_from_phone == password:
+                print('received otp from mobile successfully : %s' % otp_msg)
+                otp_info.last_otp_msg_received = otp_msg
+                otp_info.last_otp_received_time = time.time()
+
+                if m := OTP_PAT.search(otp_msg):
+                    otp_info.last_otp_received = m.group()
+                else:
+                    print('Unable to identify otp from sms')
+            else:
+                print('unknown mobile is trying to connect. Data received : %s, Otp received : %s,  Ignoring this data ...' % (data, otp_msg))
+
+
+def start_receiving_otp(password):
+    otp_info.init()
+    sock = bind_udp_socket()
+    start_new_thread(receive_otp_from_mobile, (sock, password,))
+
+
+def get_otp(otp_trigger_time):
+    # try to read OTP for atmost 3 minutes after trigger time, because after 3 minute otp will expire
+    t_end = otp_trigger_time + 60 * 3
+    while time.time() < t_end:
+        if otp_info.last_otp_received_time > otp_trigger_time:
+            print('Otp found : %s' % otp_info.last_otp_received)
+            return otp_info.last_otp_received
+        else:
+            print('No otp received Yet. Sleeping for 1 seconds before rechecking...')
+            time.sleep(1)
+    return None
+
+
+# Testing for receiver
+def main():
+    start_receiving_otp("1234")
+    while True:
+        get_otp(time.time())
+
+
+if __name__ == '__main__':
+    main()

--- a/src/otp_info.py
+++ b/src/otp_info.py
@@ -1,0 +1,9 @@
+
+def init():
+    global last_otp_received
+    global last_otp_msg_received
+    global last_otp_received_time
+    last_otp_received = None
+    last_otp_msg_received = None
+    last_otp_received_time = 0
+


### PR DESCRIPTION
1. Added a new option to retrieve the otp from mobile. Now in python script a udp server is running which listen for  otp response from app and maintains a cache.  The app can sends the otp directly if both laptop and mobile are connected on same wifi network (magic of broadcast pkt).  For security reasons added a password option, so that in same network more than one script and app can work(needed if someone is connected to shared network).
2. refactored the code, so that it can be easily extended to more otp fetchers.


New Steps :- 

In python script :- 
After asking for mobile number, now it asks for "Please select from following option to enter OTP".
If user selects option 2, which is fetch from local wifi, then it again asks for password (same should be used in mobile).

In App Side :- 
Added a new input field named :-   Enter password (it should be same as entered after choosing option 2 in script)

Enjoy :-) 