### PR TITLE
removed logic to forcefully expire token.

### DIFF
--- a/src/covid-vaccine-slot-booking.py
+++ b/src/covid-vaccine-slot-booking.py
@@ -15,7 +15,7 @@ KVDB_BUCKET = os.getenv('KVDB_BUCKET')
 
 def is_token_valid(token):
     payload = jwt.decode(token, options={"verify_signature": False})
-    remaining_seconds = payload['iat'] + 600 - int(time.time())
+    remaining_seconds = payload['exp'] - int(time.time())
     if remaining_seconds <= 1*30: # 30 secs early before expiry for clock issues
         return False
     if remaining_seconds <= 60:


### PR DESCRIPTION
Forcefully expiring the token after 10 minutes is no longer needed. tested with findbyapi and they are working till the last second of exp. 